### PR TITLE
CHANGED: Updated testapp buildfile

### DIFF
--- a/shibboleth-sp-testapp/build.sh
+++ b/shibboleth-sp-testapp/build.sh
@@ -1,2 +1,2 @@
-docker build --tag="example/shibboleth-sp:latest" .
-
+#!/bin/bash
+docker build -t example/shibboleth-sp:latest .


### PR DESCRIPTION
Testapp build.sh requires shebang in order to executable by bash

```shell
Failed to execute process './build.sh'. Reason:
exec: Exec format error
The file './build.sh' is marked as an executable but could not be run by the operating system.
Unable to find image 'example/shibboleth-sp:latest' locally
docker: Error response from daemon: pull access denied for example/shibboleth-sp, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.
```